### PR TITLE
fix!: remove has_cursor_middle fields

### DIFF
--- a/src/model/render.rs
+++ b/src/model/render.rs
@@ -56,8 +56,6 @@ pub struct Render {
     #[serde(rename = "needToRedownload")]
     pub need_to_redownload: bool,
     pub skin: Box<str>,
-    #[serde(rename = "hasCursorMiddle")]
-    pub has_cursor_middle: bool,
     #[serde(rename = "motionBlur960fps")]
     pub motion_blur: bool,
     #[serde(rename = "renderStartTime", deserialize_with = "deserialize_datetime")]

--- a/src/model/skin_list.rs
+++ b/src/model/skin_list.rs
@@ -30,7 +30,6 @@ pub struct Skin {
     pub low_res_preview: Box<str>,
     pub grid_preview: Box<str>,
     pub id: u32,
-    pub has_cursor_middle: bool,
     pub author: Box<str>,
     pub modified: bool,
     pub version: Box<str>,


### PR DESCRIPTION
Removes `Render::has_cursor_middle` and `Skin::has_cursor_middle`